### PR TITLE
Fix GitHub Pages Node version for Astro 6

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
           cache-dependency-path: ${{ env.BUILD_PATH }}/${{ steps.detect-package-manager.outputs.lockfile }}
       - name: Setup Pages

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "zeinsleiman-blog",
   "type": "module",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
## Summary\n- update the GitHub Pages workflow to use Node 22 for Astro 6 builds\n- declare the project Node requirement in package.json to match Astro 6\n\n## Why\nGitHub Pages was building the site with Node 20 while Astro 6.1.6 requires Node >=22.12.0, causing the deployment build to fail.