### PR TITLE
Fix Astro blog collection loading

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,8 @@
 import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
 
 const blog = defineCollection({
-  type: "content",
+  loader: glob({ base: "./src/content/blog", pattern: "**/*.{md,mdx}" }),
   schema: z.object({
     title: z.string(),
     date: z.coerce.date(),


### PR DESCRIPTION
## Summary\n- switch the blog collection to Astro 6's loader-based content config\n- load Markdown posts from src/content/blog with astro/loaders glob\n\n## Why\nAstro 6 no longer populates this collection from the old type-based config, so the homepage, archive, and blog routes were all missing posts locally and in builds.